### PR TITLE
!deploy v0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSProfile - ChangeLog](#psprofile---changelog)
+  * [0.1.3 - 2019-08-20](#013---2019-08-20)
   * [0.1.2 - 2019-08-20](#012---2019-08-20)
   * [0.1.1 - 2019-08-19](#011---2019-08-19)
   * [0.1.0 - 2019-08-19](#010---2019-08-19)
@@ -6,6 +7,14 @@
 ***
 
 # PSProfile - ChangeLog
+
+## 0.1.3 - 2019-08-20
+
+* Added `Confirm-ScriptIsValid` to `PSProfile.PowerTools`
+* Added `Test-RegEx` to `PSProfile.PowerTools`
+* Changed `ErrorAction` on `New-Alias` call in `$PSProfile._setCommandAliases()` method.
+* Removed `ForEach-Object` alias from `Open-Code`
+* Added `pwsh-preview` exe resolver to `Enter-CleanEnvironment` as the wrapper cmd file does not handle the arguments correctly (throws non-terminated string error).
 
 ## 0.1.2 - 2019-08-20
 

--- a/PSProfile/Classes/PSProfile.Classes.ps1
+++ b/PSProfile/Classes/PSProfile.Classes.ps1
@@ -378,7 +378,7 @@ class PSProfile {
                 $Name = $_.Key
                 $Value = $_.Value
                 if ($null -eq (Get-Alias "$Name*")) {
-                    New-Alias -Name $Name -Value $Value -Scope Global -Option AllScope -ErrorAction Stop
+                    New-Alias -Name $Name -Value $Value -Scope Global -Option AllScope -ErrorAction SilentlyContinue
                     $this._log(
                         "Set command alias: $Name > $Value",
                         'SetCommandAliases',

--- a/PSProfile/PSProfile.psd1
+++ b/PSProfile/PSProfile.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSProfile.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.2'
+ModuleVersion = '0.1.3'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop','Core')

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ _PSProfile is a cross-platform PowerShell module built for profile customization
 ### ProjectPaths
 
 ```powershell
-Add-PSProfileProjectPath C:\WorkProjects,~\PersonalGit -Verbose -Save
+Add-PSProfileProjectPath C:\WorkProjects,~\PersonalGit -Save
 ```
 
 > This adds the two folders to your ProjectPaths and refreshes your PSProfile to import any projects immediately to the internal GitPathMap. If any `build.ps1` files are found, those are added to another special dictionary in PSProfile as well for tab-completion.
@@ -77,5 +77,11 @@ Add-PSProfileProjectPath C:\WorkProjects,~\PersonalGit -Verbose -Save
     * `Start-BuildScript` (Alias: `bld`) - Use `build.ps1` scripts often for building projects? This function will invoke your build script in a new child process with `-NoProfile` included to prevent any false flags that may happen while your profile is loaded as well as prevent file-locking.
     * `Enter-CleanEnvironment` (Alias: `cln`) - Opens a child process up in the current directory with `-NoProfile` and a custom prompt to let you know you're in a _clean_ environment. Use the `-ImportModule` switch to import a compiled module in the `BuildOutput` folder of your current directly if found.
     * `Get-LongPath` (Alias: `path`) - Want to leverage tab-completion of project folder names for other commands? Use this to expand the long path of a project folder name like so, `Get-ChildItem (path PSProfile)`
+
+### ScriptPaths
+
+```powershell
+Add-PSProfileScriptPath ~\PowerShell\Profile\FunTools.ps1 -Save
+```
 
 More info / tips here soon! View the [PSProfile wiki](https://github.com/scrthq/PSProfile/wiki) for full function help and other topics.


### PR DESCRIPTION
## 0.1.3 - 2019-08-20

* Added `Confirm-ScriptIsValid` to `PSProfile.PowerTools`
* Added `Test-RegEx` to `PSProfile.PowerTools`
* Changed `ErrorAction` on `New-Alias` call in `$PSProfile._setCommandAliases()` method.
* Removed `ForEach-Object` alias from `Open-Code`
* Added `pwsh-preview` exe resolver to `Enter-CleanEnvironment` as the wrapper cmd file does not handle the arguments correctly (throws non-terminated string error).