### PR TITLE
!deploy v0.5.0 ready for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSProfile - ChangeLog](#psprofile---changelog)
+    * [0.5.0 - 2019-10-08](#050---2019-10-08)
     * [0.4.1 - 2019-10-08](#041---2019-10-08)
     * [0.4.0 - 2019-09-22](#040---2019-09-22)
     * [0.3.0 - 2019-09-07](#030---2019-09-07)
@@ -17,6 +18,12 @@
 ***
 
 # PSProfile - ChangeLog
+
+## 0.5.0 - 2019-10-08
+
+* Miscellaneous
+    * Added FileWatcher event registration to update current `$global:PSProfile` object whenever the Configuration.psd1 file has changed, enabling configuration persistence across sessions. Configuration additions and removals from one PowerShell session will immediately be reflected in other active sessions.
+    * Removed the persistence workaround the `Save()` method in favor of the Configuration.psd1 FileWatcher method.
 
 ## 0.4.1 - 2019-10-08
 

--- a/PSProfile/Classes/PSProfile.Classes.ps1
+++ b/PSProfile/Classes/PSProfile.Classes.ps1
@@ -312,15 +312,6 @@ if ($env:AWS_PROFILE) {
             "MAIN",
             "Debug"
         )
-        $conf = Import-Configuration -Name PSProfile -CompanyName 'SCRT HQ' -DefaultPath (Join-Path $PSScriptRoot "Configuration.psd1")
-        if ($conf.LastSave -gt $this.LastSave) {
-            $this._log(
-                "Configuration has been updated from another session @ $($conf.LastSave). Pulling in updated configuration before saving.",
-                "MAIN",
-                "Verbose"
-            )
-            $this | Update-Object $conf
-        }
         $out = @{ }
         $this.LastSave = [DateTime]::Now
         $this.PSObject.Properties.Name | Where-Object { $_ -ne '_internal' } | ForEach-Object {
@@ -330,7 +321,7 @@ if ($env:AWS_PROFILE) {
         $this._log(
             "PSProfile configuration has been saved.",
             "MAIN",
-            "Verbose"
+            "Debug"
         )
     }
     hidden [string] _globalize([string]$content) {

--- a/PSProfile/PSProfile.psd1
+++ b/PSProfile/PSProfile.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSProfile.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.4.0'
+    ModuleVersion        = '0.5.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop','Core')

--- a/PSProfile/PSProfile.psm1
+++ b/PSProfile/PSProfile.psm1
@@ -1,6 +1,20 @@
 # If we're in an interactive shell, load the profile.
-if ([Environment]::UserInteractive -or ($null -eq [Environment]::UserInteractive -and $null -eq ([Environment]::GetCommandLineArgs() | Where-Object {$_ -like '-NonI*'}))) {
+if ([Environment]::UserInteractive -or ($null -eq [Environment]::UserInteractive -and $null -eq ([Environment]::GetCommandLineArgs() | Where-Object { $_ -like '-NonI*' }))) {
+    $global:OriginalPrompt =
     $global:PSProfile = [PSProfile]::new()
     $global:PSProfile.Load()
     Export-ModuleMember -Variable PSProfile
+    $fsw = [System.IO.FileSystemWatcher]::new($(Split-Path $global:PSProfile.Settings.ConfigurationPath -Parent),'Configuration.psd1')
+    $global:PSProfileConfigurationWatcher = Register-ObjectEvent -InputObject $fsw -EventName Changed -Action {
+        [PSProfile]$conf = Import-Configuration -Name PSProfile -CompanyName 'SCRT HQ' -Verbose:$false
+        $conf._internal = $global:PSProfile._internal
+        $global:PSProfile = $conf
+    }
+    $PSProfile_OnRemoveScript = {
+        $global:PSProfileConfigurationWatcher.Dispose()
+        Remove-Variable PSProfileConfigurationWatcher -Scope Global -Force
+        Remove-Variable PSProfile -Scope Global -Force
+    }
+    $ExecutionContext.SessionState.Module.OnRemove += $PSProfile_OnRemoveScript
+    Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $PSProfile_OnRemoveScript
 }

--- a/PSProfile/PSProfile.psm1
+++ b/PSProfile/PSProfile.psm1
@@ -11,9 +11,12 @@ if ([Environment]::UserInteractive -or ($null -eq [Environment]::UserInteractive
         $global:PSProfile = $conf
     }
     $PSProfile_OnRemoveScript = {
-        $global:PSProfileConfigurationWatcher.Dispose()
-        Remove-Variable PSProfileConfigurationWatcher -Scope Global -Force
-        Remove-Variable PSProfile -Scope Global -Force
+        try {
+            Remove-Variable PSProfileConfigurationWatcher -Scope Global -Force
+            Remove-Variable PSProfile -Scope Global -Force
+            $global:PSProfileConfigurationWatcher.Dispose()
+        }
+        catch {}
     }
     $ExecutionContext.SessionState.Module.OnRemove += $PSProfile_OnRemoveScript
     Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $PSProfile_OnRemoveScript

--- a/PSProfile/PSProfile.psm1
+++ b/PSProfile/PSProfile.psm1
@@ -4,19 +4,20 @@ if ([Environment]::UserInteractive -or ($null -eq [Environment]::UserInteractive
     $global:PSProfile = [PSProfile]::new()
     $global:PSProfile.Load()
     Export-ModuleMember -Variable PSProfile
-    $fsw = [System.IO.FileSystemWatcher]::new($(Split-Path $global:PSProfile.Settings.ConfigurationPath -Parent),'Configuration.psd1')
-    $global:PSProfileConfigurationWatcher = Register-ObjectEvent -InputObject $fsw -EventName Changed -Action {
+    $global:PSProfileConfigurationWatcher = [System.IO.FileSystemWatcher]::new($(Split-Path $global:PSProfile.Settings.ConfigurationPath -Parent),'Configuration.psd1')
+    $job = Register-ObjectEvent -InputObject $global:PSProfileConfigurationWatcher -EventName Changed -Action {
         [PSProfile]$conf = Import-Configuration -Name PSProfile -CompanyName 'SCRT HQ' -Verbose:$false
         $conf._internal = $global:PSProfile._internal
         $global:PSProfile = $conf
     }
     $PSProfile_OnRemoveScript = {
         try {
-            Remove-Variable PSProfileConfigurationWatcher -Scope Global -Force
-            Remove-Variable PSProfile -Scope Global -Force
             $global:PSProfileConfigurationWatcher.Dispose()
         }
-        catch {}
+        finally {
+            Remove-Variable PSProfile -Scope Global -Force
+            Remove-Variable PSProfileConfigurationWatcher -Scope Global -Force
+        }
     }
     $ExecutionContext.SessionState.Module.OnRemove += $PSProfile_OnRemoveScript
     Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $PSProfile_OnRemoveScript

--- a/invoke.build.ps1
+++ b/invoke.build.ps1
@@ -217,7 +217,6 @@ task Test Init,{
         $testResults | Format-List
         Write-BuildError 'One or more Pester tests failed. Build cannot continue!'
     }
-    Pop-Location
 }
 
 $psGalleryConditions = {


### PR DESCRIPTION
## 0.5.0 - 2019-10-08

* Miscellaneous
    * Added FileWatcher event registration to update current `$global:PSProfile` object whenever the Configuration.psd1 file has changed, enabling configuration persistence across sessions. Configuration additions and removals from one PowerShell session will immediately be reflected in other active sessions.
    * Removed the persistence workaround the `Save()` method in favor of the Configuration.psd1 FileWatcher method.