### PR TITLE
!deploy v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * [PSProfile - ChangeLog](#psprofile---changelog)
+    * [0.6.0 - 2019-11-02](#060---2019-11-02)
     * [0.5.0 - 2019-10-08](#050---2019-10-08)
     * [0.4.1 - 2019-10-08](#041---2019-10-08)
     * [0.4.0 - 2019-09-22](#040---2019-09-22)
@@ -18,6 +19,25 @@
 ***
 
 # PSProfile - ChangeLog
+
+## 0.6.0 - 2019-11-02
+
+* [Issue #21](https://github.com/scrthq/PSProfile/issues/21) - _Thank you [@corbob](https://github.com/corbob)!_
+    * Fixed: Project folder discovery logic to ensure that project folders with the same name are added to the dictionary without conflict.
+* [Issue #22](https://github.com/scrthq/PSProfile/issues/22) - _Thank you [@corbob](https://github.com/corbob)!_
+    * Added: `WithInsiders` switch parameter to `Open-Code`, `Edit-PSProfilePrompt`, and `Edit-PSProfileInitScript`.
+* [Issue #23](https://github.com/scrthq/PSProfile/issues/23)
+    * Fixed: `$PSProfile` variable should exist regardless of when you import the module (removed conditional variable setting from PSM1).
+* [Issue #26](https://github.com/scrthq/PSProfile/issues/26)
+    * Fixed: `$PSProfile._globalize()` internal method will now update `$PSDefaultParameterValue` to `$global":PSDefaultParameterValue` on InitScripts / ExternalScripts / etc so `$PSDefaultParameterValue` persists in the main session as intended.
+* [Issue #27](https://github.com/scrthq/PSProfile/issues/27)
+    * Removed: `Set-Prompt` alias to prevent conflict with `oh-my-posh` module.
+* [Issue #29](https://github.com/scrthq/PSProfile/issues/29)
+    * Fixed: Secrets now persist across refreshes and sessions as intended. Details:
+        * Removed `PSProfileVault` class, replaced with pure hashtable.
+        * Updated the Secrets management functions to work directly against the Vault hashtable.
+* [Issue #31](https://github.com/scrthq/PSProfile/issues/31)
+    * Fixed: Same as [Issue #29](https://github.com/scrthq/PSProfile/issues/29).
 
 ## 0.5.0 - 2019-10-08
 

--- a/PSProfile/Classes/PSProfile.Classes.ps1
+++ b/PSProfile/Classes/PSProfile.Classes.ps1
@@ -150,9 +150,9 @@ class PSProfile {
                     Default   = "AWS: "
                 }
             }
-            PSReadline = @{
-                Options = @{}
-                KeyHandlers = @{}
+            PSReadline            = @{
+                Options     = @{ }
+                KeyHandlers = @{ }
             }
         }
         $this.RefreshFrequency = (New-TimeSpan -Hours 1).ToString()
@@ -160,7 +160,7 @@ class PSProfile {
         $this.LastSave = [datetime]::Now
         $this.ProjectPaths = @()
         $this.PluginPaths = @()
-        $this.InitScripts = @{}
+        $this.InitScripts = @{ }
         $this.ScriptPaths = @()
         $this.PathAliases = @{
             '~' = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)
@@ -245,7 +245,7 @@ if ($env:AWS_PROFILE) {
 "`n>> "'
         $plugPaths = @((Join-Path $PSScriptRoot "Plugins"))
         $curVer = (Import-Metadata (Join-Path $PSScriptRoot "PSProfile.psd1")).ModuleVersion
-        $this.PluginPaths | Where-Object {-not [string]::IsNullOrEmpty($_) -and ($_ -match "[\/\\](Modules|BuildOutput)[\/\\]PSProfile[\/\\]$curVer" -or $_ -notmatch "[\/\\](Modules|BuildOutput)[\/\\]PSProfile[\/\\]\d+\.\d+\.\d+") } | ForEach-Object {
+        $this.PluginPaths | Where-Object { -not [string]::IsNullOrEmpty($_) -and ($_ -match "[\/\\](Modules|BuildOutput)[\/\\]PSProfile[\/\\]$curVer" -or $_ -notmatch "[\/\\](Modules|BuildOutput)[\/\\]PSProfile[\/\\]\d+\.\d+\.\d+") } | ForEach-Object {
             $plugPaths += $_
         }
         $this.PluginPaths = $plugPaths | Select-Object -Unique
@@ -351,16 +351,16 @@ if ($env:AWS_PROFILE) {
                 "Verbose"
             )
             [hashtable[]]$final = @()
-            $this.$section | Where-Object {$_ -is [hashtable] -and $_.Name} | ForEach-Object {
+            $this.$section | Where-Object { $_ -is [hashtable] -and $_.Name } | ForEach-Object {
                 $final += $_
             }
-            $this.$section | Where-Object {$_ -is [string]} | ForEach-Object {
+            $this.$section | Where-Object { $_ -is [string] } | ForEach-Object {
                 $this._log(
                     "[$section] Converting module string to hashtable: $_",
                     "CleanConfig",
                     "Verbose"
                 )
-                $final += @{Name = $_}
+                $final += @{Name = $_ }
             }
             $this.$section = $final
         }
@@ -371,7 +371,7 @@ if ($env:AWS_PROFILE) {
                 "Verbose"
             )
             [string[]]$final = @()
-            $this.$section | Where-Object {-not [string]::IsNullOrEmpty($_)} | ForEach-Object {
+            $this.$section | Where-Object { -not [string]::IsNullOrEmpty($_) } | ForEach-Object {
                 $final += $_
             }
             $this.$section = $final
@@ -638,7 +638,7 @@ if ($env:AWS_PROFILE) {
                     $g = 0
                     $b = 0
                     $pInfo.EnumerateDirectories('.git',[System.IO.SearchOption]::AllDirectories) | ForEach-Object {
-                        $PathName = $_.Parent.BaseName
+                        $PathName = $_.Parent.Name
                         $FullPathName = $_.Parent.FullName
                         $g++
                         $this._log(
@@ -646,25 +646,25 @@ if ($env:AWS_PROFILE) {
                             'FindProjects',
                             'Verbose'
                         )
-                            $currPath = $_
-                            while($this.GitPathMap.ContainsKey($PathName)){
-                                $currPath = $currPath.Parent
-                                $doublePath = [System.IO.DirectoryInfo]::new($this.GitPathMap[$PathName])
-                                $this.GitPathMap["$($doublePath.Parent)\$($doublePath.BaseName)"] = $doublePath.FullName
-                                $this.GitPathMap.Remove($PathName)
-                                if($this.PSBuildPathMap.ContainsKey($PathName)){
-                                    $PSBuildPath = [System.IO.DirectoryInfo]::new($this.PSBuildPathMap[$PathName])
-                                    $this.PSBuildPathMap["$($PSBuildPath.Parent)\$($PSBuildPath.BaseName)"] = $doublePath.FullName
-                                    $this.PSBuildPathMap.Remove($PathName)
-                                }
-                                $PathName = "$($currPath.Parent.BaseName)\$PathName"
+                        $currPath = $_
+                        while ($this.GitPathMap.ContainsKey($PathName)) {
+                            $currPath = $currPath.Parent
+                            $doublePath = [System.IO.DirectoryInfo]::new($this.GitPathMap[$PathName])
+                            $this.GitPathMap["$($doublePath.Parent.Name)$([System.IO.Path]::DirectorySeparatorChar)$($doublePath.Name)"] = $doublePath.FullName
+                            $this.GitPathMap.Remove($PathName)
+                            if ($this.PSBuildPathMap.ContainsKey($PathName)) {
+                                $PSBuildPath = [System.IO.DirectoryInfo]::new($this.PSBuildPathMap[$PathName])
+                                $this.PSBuildPathMap["$($PSBuildPath.Parent.Name)$([System.IO.Path]::DirectorySeparatorChar)$($PSBuildPath.Name)"] = $doublePath.FullName
+                                $this.PSBuildPathMap.Remove($PathName)
                             }
+                            $PathName = "$($currPath.Parent.BaseName)$([System.IO.Path]::DirectorySeparatorChar)$PathName"
+                        }
                         $this.GitPathMap[$PathName] = $FullPathName
                         $bldPath = [System.IO.Path]::Combine($FullPathName,'build.ps1')
                         if ([System.IO.File]::Exists($bldPath)) {
                             $b++
                             $this._log(
-                                "Found build script @ $($_.FullName)",
+                                "Found build script @ $($bldPath)",
                                 'FindProjects',
                                 'Verbose'
                             )
@@ -954,74 +954,74 @@ if ($env:AWS_PROFILE) {
         )
         if ($this.Plugins.Count) {
             $this.Plugins.ForEach( {
-                if ($_.Name -ne 'PSProfile.PowerTools') {
-                    $plugin = $_
-                    $this._log(
-                        "'$($plugin.Name)' Searching for plugin",
-                        'LoadPlugins',
-                        'Verbose'
-                    )
-                    try {
-                        $found = $null
-                        $importParams = @{
-                            ErrorAction = 'Stop'
-                            Global      = $true
-                        }
-                        if ($plugin.ArgumentList) {
-                            $importParams['ArgumentList'] = $plugin.ArgumentList
-                        }
-                        [string[]]$pathsToSearch = @($this.PluginPaths)
-                        $env:PSModulePath.Split([System.IO.Path]::PathSeparator) | ForEach-Object {
-                            $pathsToSearch += $_
-                        }
-                        foreach ($plugPath in $pathsToSearch) {
-                            $fullPath = [System.IO.Path]::Combine($plugPath,"$($plugin.Name).ps1")
-                            $this._log(
-                                "'$($plugin.Name)' Checking path: $fullPath",
-                                'LoadPlugins',
-                                'Debug'
-                            )
-                            if (Test-Path $fullPath) {
-                                $sb = [scriptblock]::Create($this._globalize(([System.IO.File]::ReadAllText($fullPath))))
-                                if ($plugin.ArgumentList) {
-                                    .$sb($plugin.ArgumentList)
-                                }
-                                else {
-                                    .$sb
-                                }
-                                $found = $fullPath
-                                break
+                    if ($_.Name -ne 'PSProfile.PowerTools') {
+                        $plugin = $_
+                        $this._log(
+                            "'$($plugin.Name)' Searching for plugin",
+                            'LoadPlugins',
+                            'Verbose'
+                        )
+                        try {
+                            $found = $null
+                            $importParams = @{
+                                ErrorAction = 'Stop'
+                                Global      = $true
                             }
-                        }
-                        if ($null -ne $found) {
-                            $this._log(
-                                "'$($plugin.Name)' plugin loaded from path: $found",
-                                'LoadPlugins',
-                                'Verbose'
-                            )
-                        }
-                        else {
-                            if ($null -ne $plugin.Name -and $null -ne (Get-Module $plugin.Name -ListAvailable -ErrorAction SilentlyContinue)) {
-                                Import-Module $plugin.Name @importParams
+                            if ($plugin.ArgumentList) {
+                                $importParams['ArgumentList'] = $plugin.ArgumentList
+                            }
+                            [string[]]$pathsToSearch = @($this.PluginPaths)
+                            $env:PSModulePath.Split([System.IO.Path]::PathSeparator) | ForEach-Object {
+                                $pathsToSearch += $_
+                            }
+                            foreach ($plugPath in $pathsToSearch) {
+                                $fullPath = [System.IO.Path]::Combine($plugPath,"$($plugin.Name).ps1")
                                 $this._log(
-                                    "'$($plugin.Name)' plugin loaded from PSModulePath!",
-                                    'LoadPlugins'
+                                    "'$($plugin.Name)' Checking path: $fullPath",
+                                    'LoadPlugins',
+                                    'Debug'
+                                )
+                                if (Test-Path $fullPath) {
+                                    $sb = [scriptblock]::Create($this._globalize(([System.IO.File]::ReadAllText($fullPath))))
+                                    if ($plugin.ArgumentList) {
+                                        .$sb($plugin.ArgumentList)
+                                    }
+                                    else {
+                                        .$sb
+                                    }
+                                    $found = $fullPath
+                                    break
+                                }
+                            }
+                            if ($null -ne $found) {
+                                $this._log(
+                                    "'$($plugin.Name)' plugin loaded from path: $found",
+                                    'LoadPlugins',
+                                    'Verbose'
                                 )
                             }
                             else {
-                                $this._log(
-                                    "'$($plugin.Name)' plugin not found! To remove this plugin from your profile, run 'Remove-PSProfilePlugin $($plugin.Name)'",
-                                    'LoadPlugins',
-                                    'Warning'
-                                )
+                                if ($null -ne $plugin.Name -and $null -ne (Get-Module $plugin.Name -ListAvailable -ErrorAction SilentlyContinue)) {
+                                    Import-Module $plugin.Name @importParams
+                                    $this._log(
+                                        "'$($plugin.Name)' plugin loaded from PSModulePath!",
+                                        'LoadPlugins'
+                                    )
+                                }
+                                else {
+                                    $this._log(
+                                        "'$($plugin.Name)' plugin not found! To remove this plugin from your profile, run 'Remove-PSProfilePlugin $($plugin.Name)'",
+                                        'LoadPlugins',
+                                        'Warning'
+                                    )
+                                }
                             }
                         }
+                        catch {
+                            throw
+                        }
                     }
-                    catch {
-                        throw
-                    }
-                }
-            })
+                })
         }
         else {
             $this._log(

--- a/PSProfile/PSProfile.Aliases.ps1
+++ b/PSProfile/PSProfile.Aliases.ps1
@@ -5,7 +5,6 @@
     'Save-Prompt'            = 'Add-PSProfilePrompt'
     'Get-Prompt'             = 'Get-PSProfilePrompt'
     'Edit-Prompt'            = 'Edit-PSProfilePrompt'
-    'Set-Prompt'             = 'Switch-PSProfilePrompt'
     'Switch-Prompt'          = 'Switch-PSProfilePrompt'
     'Remove-Prompt'          = 'Remove-PSProfilePrompt'
     'Copy-DynamicParameters' = 'Copy-Parameters'

--- a/PSProfile/PSProfile.psd1
+++ b/PSProfile/PSProfile.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PSProfile.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.5.0'
+    ModuleVersion        = '0.6.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop','Core')

--- a/PSProfile/PSProfile.psm1
+++ b/PSProfile/PSProfile.psm1
@@ -1,24 +1,20 @@
-# If we're in an interactive shell, load the profile.
-if ([Environment]::UserInteractive -or ($null -eq [Environment]::UserInteractive -and $null -eq ([Environment]::GetCommandLineArgs() | Where-Object { $_ -like '-NonI*' }))) {
-    $global:OriginalPrompt =
-    $global:PSProfile = [PSProfile]::new()
-    $global:PSProfile.Load()
-    Export-ModuleMember -Variable PSProfile
-    $global:PSProfileConfigurationWatcher = [System.IO.FileSystemWatcher]::new($(Split-Path $global:PSProfile.Settings.ConfigurationPath -Parent),'Configuration.psd1')
-    $job = Register-ObjectEvent -InputObject $global:PSProfileConfigurationWatcher -EventName Changed -Action {
-        [PSProfile]$conf = Import-Configuration -Name PSProfile -CompanyName 'SCRT HQ' -Verbose:$false
-        $conf._internal = $global:PSProfile._internal
-        $global:PSProfile = $conf
-    }
-    $PSProfile_OnRemoveScript = {
-        try {
-            $global:PSProfileConfigurationWatcher.Dispose()
-        }
-        finally {
-            Remove-Variable PSProfile -Scope Global -Force
-            Remove-Variable PSProfileConfigurationWatcher -Scope Global -Force
-        }
-    }
-    $ExecutionContext.SessionState.Module.OnRemove += $PSProfile_OnRemoveScript
-    Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $PSProfile_OnRemoveScript
+$global:PSProfile = [PSProfile]::new()
+$global:PSProfile.Load()
+Export-ModuleMember -Variable PSProfile
+$global:PSProfileConfigurationWatcher = [System.IO.FileSystemWatcher]::new($(Split-Path $global:PSProfile.Settings.ConfigurationPath -Parent),'Configuration.psd1')
+$job = Register-ObjectEvent -InputObject $global:PSProfileConfigurationWatcher -EventName Changed -Action {
+    [PSProfile]$conf = Import-Configuration -Name PSProfile -CompanyName 'SCRT HQ' -Verbose:$false
+    $conf._internal = $global:PSProfile._internal
+    $global:PSProfile = $conf
 }
+$PSProfile_OnRemoveScript = {
+    try {
+        $global:PSProfileConfigurationWatcher.Dispose()
+    }
+    finally {
+        Remove-Variable PSProfile -Scope Global -Force
+        Remove-Variable PSProfileConfigurationWatcher -Scope Global -Force
+    }
+}
+$ExecutionContext.SessionState.Module.OnRemove += $PSProfile_OnRemoveScript
+Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $PSProfile_OnRemoveScript

--- a/PSProfile/Public/Secrets/Add-PSProfileSecret.ps1
+++ b/PSProfile/Public/Secrets/Add-PSProfileSecret.ps1
@@ -52,26 +52,29 @@ function Add-PSProfileSecret {
     Process {
         switch ($PSCmdlet.ParameterSetName) {
             PSCredential {
-                if ($Force -or $null -eq $Global:PSProfile.Vault.GetSecret($Credential.UserName)) {
+                if ($Force -or -not $Global:PSProfile.Vault._secrets.ContainsKey($Credential.UserName)) {
                     Write-Verbose "Adding PSCredential for user '$($Credential.UserName)' to `$PSProfile.Vault"
-                    $Global:PSProfile.Vault.SetSecret($Credential)
+                    $Global:PSProfile.Vault._secrets[$Credential.UserName] = $Credential
+                    if ($Save) {
+                        Save-PSProfile
+                    }
                 }
-                elseif (-not $Force -and $null -ne $Global:PSProfile.Vault.GetSecret($Credential.UserName)) {
+                elseif (-not $Force -and $Global:PSProfile.Vault._secrets.ContainsKey($Credential.UserName)) {
                     Write-Error "A secret with the name '$($Credential.UserName)' already exists! Include -Force to overwrite it."
                 }
             }
             SecureString {
-                if ($Force -or $null -eq $Global:PSProfile.Vault.GetSecret($Name)) {
+                if ($Force -or -not $Global:PSProfile.Vault._secrets.ContainsKey($Name)) {
                     Write-Verbose "Adding SecureString secret with name '$Name' to `$PSProfile.Vault"
-                    $Global:PSProfile.Vault.SetSecret($Name,$SecureString)
+                    $Global:PSProfile.Vault._secrets[$Name] = $SecureString
+                    if ($Save) {
+                        Save-PSProfile
+                    }
                 }
-                elseif (-not $Force -and $null -ne $Global:PSProfile.Vault.GetSecret($Name)) {
+                elseif (-not $Force -and $Global:PSProfile.Vault._secrets.ContainsKey($Name)) {
                     Write-Error "A secret with the name '$Name' already exists! Include -Force to overwrite it."
                 }
             }
-        }
-        if ($Save) {
-            Save-PSProfile
         }
     }
 }

--- a/PSProfile/Public/Secrets/Get-MyCreds.ps1
+++ b/PSProfile/Public/Secrets/Get-MyCreds.ps1
@@ -46,7 +46,7 @@ function Get-MyCreds {
     Process {
         if ($Item) {
             Write-Verbose "Checking Credential Vault for user '$Item'"
-            if ($creds = $global:PSProfile.Vault.GetSecret($Item)) {
+            if ($creds = $global:PSProfile.Vault._secrets[$Item]) {
                 Write-Verbose "Found item in CredStore"
                 if (!$env:USERDOMAIN) {
                     $env:USERDOMAIN = [System.Environment]::MachineName
@@ -59,7 +59,7 @@ function Get-MyCreds {
             else {
                 $PSCmdlet.ThrowTerminatingError(
                     [System.Management.Automation.ErrorRecord]::new(
-                        ([System.Management.Automation.ItemNotFoundException]"Could not find secret item '$Item' in the PSProfileVault"),
+                        ([System.Management.Automation.ItemNotFoundException]"Could not find secret '$Item' in `$PSProfile.Vault"),
                         'PSProfile.Vault.SecretNotFound',
                         [System.Management.Automation.ErrorCategory]::InvalidArgument,
                         $global:PSProfile

--- a/PSProfile/Public/Secrets/Remove-PSProfileSecret.ps1
+++ b/PSProfile/Public/Secrets/Remove-PSProfileSecret.ps1
@@ -31,7 +31,7 @@ function Remove-PSProfileSecret {
         if ($PSCmdlet.ShouldProcess("Removing '$Name' from `$PSProfile.Vault")) {
             if ($Global:PSProfile.Vault._secrets.ContainsKey($Name)) {
                 Write-Verbose "Removing '$Name' from `$PSProfile.Vault"
-                $Global:PSProfile.Vault.RemoveSecret($Name)
+                $Global:PSProfile.Vault._secrets.Remove($Name) | Out-Null
             }
             if ($Save) {
                 Save-PSProfile


### PR DESCRIPTION
## 0.6.0 - 2019-11-02

* [Issue #21](https://github.com/scrthq/PSProfile/issues/21) - _Thank you [@corbob](https://github.com/corbob)!_
    * Fixed: Project folder discovery logic to ensure that project folders with the same name are added to the dictionary without conflict.
* [Issue #22](https://github.com/scrthq/PSProfile/issues/22) - _Thank you [@corbob](https://github.com/corbob)!_
    * Added: `WithInsiders` switch parameter to `Open-Code`, `Edit-PSProfilePrompt`, and `Edit-PSProfileInitScript`.
* [Issue #23](https://github.com/scrthq/PSProfile/issues/23)
    * Fixed: `$PSProfile` variable should exist regardless of when you import the module (removed conditional variable setting from PSM1).
* [Issue #26](https://github.com/scrthq/PSProfile/issues/26)
    * Fixed: `$PSProfile._globalize()` internal method will now update `$PSDefaultParameterValue` to `$global":PSDefaultParameterValue` on InitScripts / ExternalScripts / etc so `$PSDefaultParameterValue` persists in the main session as intended.
* [Issue #27](https://github.com/scrthq/PSProfile/issues/27)
    * Removed: `Set-Prompt` alias to prevent conflict with `oh-my-posh` module.
* [Issue #29](https://github.com/scrthq/PSProfile/issues/29)
    * Fixed: Secrets now persist across refreshes and sessions as intended. Details:
        * Removed `PSProfileVault` class, replaced with pure hashtable.
        * Updated the Secrets management functions to work directly against the Vault hashtable.
* [Issue #31](https://github.com/scrthq/PSProfile/issues/31)
    * Fixed: Same as [Issue #29](https://github.com/scrthq/PSProfile/issues/29).